### PR TITLE
Fix infinite loop on corrupted input data in lzlib_decompress

### DIFF
--- a/lzlib.c
+++ b/lzlib.c
@@ -855,7 +855,7 @@ static int lzlib_decompress(lua_State *L)
             break;
 
         if (ret == Z_BUF_ERROR && 0 < zs.avail_out) {
-            lua.pushliteral(L, "input buffer error, input data may be corrupted");
+            lua_pushliteral(L, "input buffer error, input data may be corrupted");
             lua_error(L);
         }
 

--- a/lzlib.c
+++ b/lzlib.c
@@ -854,6 +854,11 @@ static int lzlib_decompress(lua_State *L)
         if (ret == Z_STREAM_END)
             break;
 
+        if (ret == Z_BUF_ERROR && 0 < zs.avail_out) {
+            lua.pushliteral(L, "input buffer error, input data may be corrupted");
+            lua_error(L);
+        }
+
         if (ret != Z_OK && ret != Z_BUF_ERROR) {
             /* cleanup */
             inflateEnd(&zs);


### PR DESCRIPTION
Corrupt input data can cause inflate() to return Z_BUF_ERROR infinitely, causing an infinite loop in lzlib_decompress. This change throws an error instead. Solution taken from http://bugs.python.org/issue216267