### PR TITLE
In debug builds on windows zlib have name zlibd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required ( VERSION 2.8 )
 include ( cmake/dist.cmake )
 include ( lua )
 
-find_library ( Z_LIBRARY NAMES zlib z )
+find_library ( Z_LIBRARY NAMES zlib zlibd z )
 # Find zlib
 
 install_lua_module ( zlib lzlib.c zlib.def LINK ${Z_LIBRARY} )


### PR DESCRIPTION
In debug builds on windows 'zlib' have name 'zlibd'
So I add 'zlibd' in 'find_library' command of CMakeList.txt
I tested it in windows VisualStudio 2010 x64 build.